### PR TITLE
QOL for Player Movement

### DIFF
--- a/control/CController.gd
+++ b/control/CController.gd
@@ -188,7 +188,7 @@ func find_path(tile_position: Vector2i):
 func move_player():
 	var current_position = tile_map.local_to_map(controlled_node.position)
 	var _path_size = _path.size()
-	if _path_size > 1 and _path_size - 1 <= movement:
+	if _path_size > 1 and movement > 0:
 		move_on_path(current_position)
 
 


### PR DESCRIPTION
This change lets players click wherever when attempting to move. They unit will only move along the path as far as their remaining movement will allow.

Closes #1 